### PR TITLE
calllbacks & implicit start

### DIFF
--- a/examples/grape.js
+++ b/examples/grape.js
@@ -11,7 +11,7 @@ var g1 = new Grape({
 })
 
 g1.start(() => {
-  console.log('grape1: started')       
+  console.log('grape1: started')
 })
 
 var g2 = new Grape({
@@ -23,5 +23,5 @@ var g2 = new Grape({
 })
 
 g2.start(() => {
-  console.log('grape2: started')       
+  console.log('grape2: started')
 })

--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -177,7 +177,7 @@ class Grape extends Events {
 
   lookup (val, cb) {
     cb = cb || noop
-    
+
     var ih = this.str2Hex(val)
 
     this.start(err => {

--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -25,6 +25,7 @@ class Grape extends Events {
 
     _.extend(this.conf, conf)
 
+    this._running = false
     this._mem = {}
   }
 
@@ -165,28 +166,49 @@ class Grape extends Events {
   }
 
   announce (val, port, cb) {
-    this.node.announce(this.str2Hex(val), port || this.conf.dht_port, cb ? cb : noop)
+    cb = cb || noop
+
+    this.start(err => {
+      if (err) return cb(err)
+
+      this.node.announce(this.str2Hex(val), port || this.conf.dht_port, cb)
+    })
   }
 
   lookup (val, cb) {
+    cb = cb || noop
+    
     var ih = this.str2Hex(val)
 
-    this.node.lookup(ih, (err) => {
-      var res = []
+    this.start(err => {
+      if (err) return cb(err)
 
-      if (this._mem[ih]) {
-        let me = this._mem[ih]
-        res = _.reduce(me.peers, (acc, v, k) => {
-          acc.push(k)
-          return acc
-        }, [])
-      }
+      this.node.lookup(ih, (err) => {
+        var res = []
 
-      cb(res)
+        if (this._mem[ih]) {
+          let me = this._mem[ih]
+          res = _.reduce(me.peers, (acc, v, k) => {
+            acc.push(k)
+            return acc
+          }, [])
+        }
+
+        cb(null, res)
+      })
     })
   }
 
   start (cb) {
+    cb = cb || noop
+
+    if (this._running) {
+      debug('skipping start, since Grape is already running')
+      return cb()
+    }
+
+    debug('starting')
+
     this.create_node(this.conf.dht_port, this.conf.dht_bootstrap, (err, node) => {
       if (err) return cb(err)
 
@@ -209,6 +231,8 @@ class Grape extends Events {
             })
           })
         })
+
+        this._running = true
 
         cb()
         cb = noop
@@ -241,6 +265,9 @@ class Grape extends Events {
     ], (err) => {
       delete this.node
       delete this.transport
+
+      this._running = false
+
       cb(err)
     })
   }

--- a/test/Grape.js
+++ b/test/Grape.js
@@ -41,6 +41,20 @@ describe('Grape', () => {
     grape.stop(done)
   })
 
+  it('start is implicitly called', (done) => {
+    var grape = new Grape({dht_port: 20000, api_port: 20001, dht_bootstrap: ['127.0.0.1:20000']})
+
+    grape.announce('test', 1000, (err, result) => {
+      assert.ifError(err)
+
+      grape.lookup('test', function (err, result) {
+        assert.ifError(err)
+        assert.equal('tcp://127.0.0.1:1000', result)
+        grape.stop(done)
+      })
+    })
+  })
+
   describe('errors', () => {
     it('should error when api_port is already in use', (done) => {
       var grape1 = new Grape({


### PR DESCRIPTION
- changed some methods so that the callbacks always returned the first param as an error (as per node convention)
- made it possible to leave out the start call when using grape.