### PR TITLE
core: emit dht events

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -39,22 +39,27 @@ class Grape extends Events {
     dht.on('announce', (_peer, ih) => {
       const val = this.hex2str(ih)
       debug(this.conf.dht_port, 'announce', val)
+      this.emit('announce', val)
     })
 
     dht.on('warning', () => {
       debug(this.conf.dht_port, 'warning')
+      this.emit('warning')
     })
 
     dht.on('node', () => {
       debug(this.conf.dht_port, 'node')
+      this.emit('node')
     })
 
     dht.on('listening', () => {
       debug(this.conf.dht_port, 'listening')
+      this.emit('listening')
     })
 
     dht.on('ready', () => {
       debug(this.conf.dht_port, 'ready')
+      this.emit('ready')
     })
 
     dht.on('error', (err) => {
@@ -81,6 +86,7 @@ class Grape extends Events {
       }
 
       debug(this.conf.dht_port, 'found potential peer ' + peer + (from ? ' through ' + from.address + ':' + from.port : '') + ' for hash: ' + val)
+      this.emit('peer', peer)
     })
 
     dht.once('error', handleBootstrapError)

--- a/test/Grape.js
+++ b/test/Grape.js
@@ -62,70 +62,12 @@ describe('Grape', () => {
   })
 
   describe('lookup', () => {
-    it('start is implicitly called', (done) => {
-      var grape = new Grape({dht_port: 20000, api_port: 20001, dht_bootstrap: ['127.0.0.1:20000']})
-
-      grape.announce('test', 1000, (err, result) => {
-        assert.ifError(err)
-
-        grape.lookup('test', function (err, result) {
-          assert.ifError(err)
-          assert.equal('tcp://127.0.0.1:1000', result)
-          grape.stop(done)
-        })
-      })
-    })
-
     // TODO: confirm we can enforce value is always a string rule
     it.skip('errors when invalid value is passed', (done) => {
       var grape = new Grape({dht_port: 20000, api_port: 20001, dht_bootstrap: ['127.0.0.1:20000']})
       grape.lookup(false, (err) => {
         assert.ok(err instanceof Error)
         grape.stop(done)
-      })
-    })
-  })
-
-  describe('errors', () => {
-    it('should error when api_port is already in use', (done) => {
-      var grape1 = new Grape({
-        dht_port: 20000,
-        api_port: 20001
-      })
-
-      var grape2 = new Grape({
-        dht_port: 30000,
-        api_port: 20001 // same
-      })
-
-      grape1.start((err) => {
-        assert.ifError(err)
-        grape2.start((err) => {
-          assert.ok(err instanceof Error)
-          assert.equal('EADDRINUSE', err.code)
-          grape1.stop(done)
-        })
-      })
-    })
-
-    it('should error when dht_port is already in use', (done) => {
-      var grape1 = new Grape({
-        dht_port: 20000,
-        api_port: 20001
-      })
-
-      var grape2 = new Grape({
-        dht_port: 20000, // same
-        api_port: 30000
-      })
-
-      grape1.start((err) => {
-        assert.ifError(err)
-        grape2.start((err) => {
-          assert.ok(err instanceof Error)
-          assert.equal('EADDRINUSE', err.code)
-          grape1.stop(done)
-        })
       })
     })
   })


### PR DESCRIPTION
This makes programatic use easier, e.g. in tests we can wait for
the first announce and then kick off the client.