### PR TITLE
core: return error if no port given

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -223,7 +223,7 @@ class Grape extends Events {
   }
 
   transportHttp (cb) {
-    if (!this.conf.api_port_http) return cb()
+    if (!this.conf.api_port_http) return cb(new Error('ERR_NO_PORT'))
 
     let fetchRequest = (req, rep) => {
       let body = []


### PR DESCRIPTION
http port _must_ be specified.

avoids silent fails