### PR TITLE
perf: cache lookups

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -183,6 +183,11 @@ class Grape extends Events {
   lookup (val, cb) {
     const ih = this.str2hex(val)
 
+    const meCached = this._mem.get(ih)
+    if (meCached) {
+      return cb(null, _.keys(meCached.peers))
+    }
+
     this.node.lookup(ih, (err) => {
       if (err) return cb(err)
 


### PR DESCRIPTION
With cached lookups I'm able to run with 120 clients instead
of 70.

setup:
 - 50 workers, announcing every 500ms
 - clients: interval 50ms