### PR TITLE
mutable-values: decode buffer to strings

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -251,10 +251,24 @@ class Grape extends Events {
   get (hash, cb) {
     try {
       this.node.get(hash, (err, res) => {
-        if (res) {
-          res.id = this.str2hex(res.id)
-          res.v = res.v.toString()
+        if (!res) {
+          return cb(err)
         }
+
+        res.id = this.str2hex(res.id)
+        res.v = res.v.toString()
+
+        if (res.k) {
+          res.k = res.k.toString('hex')
+        }
+        if (res.sig) {
+          res.sig = res.sig.toString('hex')
+        }
+
+        if (res.salt) {
+          res.salt = res.salt.toString()
+        }
+
         cb(err, res)
       })
     } catch (e) {


### PR DESCRIPTION
if not decoded, grape will apply `JSON.stringify` on the buffer
returned by bittorrent_dht:

```
rep.end(JSON.stringify(err ? err.message : res))
```

This leads to a HTTP response with `k` and `sig` with JSON of:
`type: "Buffer", data: [200, 32, 211 ... ]`

Example:

```
JSON.stringify(new Buffer('foo'))
'{"type":"Buffer","data":[102,111,111]}'
```