### PR TITLE
http: pass error code to clients

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -311,6 +311,10 @@ class Grape extends Events {
       const data = msg.data
 
       this.onRequest(type, data, (err, res) => {
+        if (err && err.code) {
+          rep.statusCode = err.code
+        }
+
         rep.end(JSON.stringify(err ? err.message : res))
       })
     }


### PR DESCRIPTION
in case of errors coming from dht/k-rpc, we pass the error code
back to the client to be able to handle them better.

discussion with examples:

https://github.com/bitfinexcom/grenache/issues/12