### PR TITLE
bep44: catch error for invalid payloads

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -242,11 +242,15 @@ class Grape extends Events {
   put (opts, cb) {
     cb = cb || noop
 
-    this.node.put(opts, (err, res) => {
-      if (err) return cb(err)
+    try {
+      this.node.put(opts, (err, res) => {
+        if (err) return cb(err)
 
-      cb(null, this.str2hex(res))
-    })
+        cb(null, this.str2hex(res))
+      })
+    } catch (e) {
+      cb(e)
+    }
   }
 
   get (hash, cb) {

--- a/test/Grape.js
+++ b/test/Grape.js
@@ -68,17 +68,21 @@ describe('Grape', () => {
 
     grape.start((err) => {
       assert.ok(err)
-      done()
+      grape.stop(done)
     })
   })
 
-  describe('lookup', () => {
-    // TODO: confirm we can enforce value is always a string rule
-    it.skip('errors when invalid value is passed', (done) => {
-      const grape = new Grape({dht_port: 20000, api_port: 20001, dht_bootstrap: ['127.0.0.1:20000']})
-      grape.lookup(false, (err) => {
-        assert.ok(err instanceof Error)
-        grape.stop(done)
+  it('keeps running on invalid put payload', (done) => {
+    const grape = new Grape({
+      dht_port: 20000,
+      api_port: 20001
+    })
+
+    grape.start((err) => {
+      if (err) throw err
+      grape.put({ foo: 'bar' }, (err) => {
+        assert.ok(err)
+        done()
       })
     })
   })


### PR DESCRIPTION
DHT throws on invalid payloads, which can take down grape when a
client constructs bad requests.

https://github.com/webtorrent/bittorrent-dht/blob/c2cb22020289319fb5007429683a88291c0b3669/client.js#L250