### PR TITLE
bep44: hex encode buffer values for token

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -253,6 +253,10 @@ class Grape extends Events {
           res.salt = res.salt.toString()
         }
 
+        if (res.token) {
+          res.token = res.token.toString('hex')
+        }
+
         cb(err, res)
       })
     } catch (e) {


### PR DESCRIPTION
hex encode to be friendly to `JSON.stringify` with the Buffer

![screen shot 2018-06-12 at 20 56 26](https://user-images.githubusercontent.com/298166/41310892-1b638fca-6e83-11e8-8eb3-58437f9b5f78.png)
