### PR TITLE
cli: throw error when port is already used

### DIFF
--- a/bin/grape.js
+++ b/bin/grape.js
@@ -99,4 +99,6 @@ const g = new Grape({
   check_maxPayloadSize: maxPayloadSize
 })
 
-g.start(() => {})
+g.start((err) => {
+  if (err) throw err
+})


### PR DESCRIPTION
when having another grape process running now, e.g. from
testing, and starting another grape accidentally, the grape
fails silently, leading to the service not being announced on the
network.