### PR TITLE
hyperswarm dht integration

### DIFF
--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -20,7 +20,7 @@ class Grape extends Events {
       dht_maxTables: 5000,
       dht_maxValues: 5000,
       dht_port: 20001,
-      dht_bootstrap: undefined, // defaults to hyperswarm public bootstrap servers
+      dht_bootstrap: [],
       dht_concurrency: 24,
       dht_nodeLiveness: 5 * 60 * 1000, // 5 min
       api_port: null,

--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -1,14 +1,12 @@
 'use strict'
-
-const DHT = require('bittorrent-dht')
+const { createHash } = require('crypto')
+const DHT = require('@hyperswarm/dht')
 const records = require('record-cache')
 const _ = require('lodash')
-const CbQ = require('cbq')
 const async = require('async')
 const http = require('http')
 const Events = require('events')
 const debug = require('debug')('grenache:grape')
-const crypto = require('ed25519-supercop')
 const getRawBody = require('raw-body')
 
 const noop = () => {}
@@ -22,7 +20,7 @@ class Grape extends Events {
       dht_maxTables: 5000,
       dht_maxValues: 5000,
       dht_port: 20001,
-      dht_bootstrap: [],
+      dht_bootstrap: undefined, // defaults to hyperswarm public bootstrap servers
       dht_concurrency: 24,
       dht_nodeLiveness: 5 * 60 * 1000, // 5 min
       api_port: null,
@@ -35,24 +33,21 @@ class Grape extends Events {
       maxAge: Math.ceil(this.conf.dht_peer_maxAge / 2)
     })
 
-    this.cbq0 = new CbQ()
-
     this._interface = {}
     this._active = false
+    this.listening = false
   }
 
   createNode (cb) {
-    const dht = new DHT({
-      maxTables: this.conf.dht_maxTables,
-      maxValues: this.conf.dht_maxValues,
-      host: this.conf.host || false,
-      bootstrap: this.conf.dht_bootstrap,
-      timeBucketOutdated: this.conf.dht_nodeLiveness,
-      verify: crypto.verify,
+    const dht = this.dht = DHT({
+      // maxTables: this.conf.dht_maxTables,
+      // maxValues: this.conf.dht_maxValues,
+      bootstrap: this.conf.dht_bootstrap || undefined,
+      // timeBucketOutdated: this.conf.dht_nodeLiveness,
       maxAge: this.conf.dht_peer_maxAge
     })
 
-    dht.on('announce', (_peer, ih) => {
+    dht.on('announce', (ih, _peer) => {
       const val = this.hex2str(ih)
       debug(this.conf.dht_port, 'announce', val)
       this.emit('announce', val)
@@ -63,13 +58,14 @@ class Grape extends Events {
       this.emit('warning')
     })
 
-    dht.on('node', () => {
+    dht.on('add-node', () => {
       debug(this.conf.dht_port, 'node')
       this.emit('node')
     })
 
     dht.on('listening', () => {
       debug(this.conf.dht_port, 'listening')
+      this.listening = true
       this.emit('listening')
     })
 
@@ -82,23 +78,13 @@ class Grape extends Events {
       debug(this.conf.dht_port, 'error', err)
     })
 
-    dht.on('peer', (_peer, val, from) => {
-      const ih = this.str2hex(val)
-      const peer = `${_peer.host}:${_peer.port}`
-
-      this._mem.add(ih, peer)
-
-      debug(this.conf.dht_port, 'found potential peer ' + peer + (from ? ' through ' + from.address + ':' + from.port : '') + ' for hash: ' + val)
-      this.emit('peer', peer)
-    })
-
     dht.once('error', handleBootstrapError)
 
     function handleBootstrapError (err) {
       cb(err)
     }
 
-    dht.listen(this.conf.dht_port, (err) => {
+    dht.listen(this.conf.dht_port, this.conf.host, (err) => {
       dht.removeListener('error', handleBootstrapError)
       if (err) return cb(err)
 
@@ -120,6 +106,12 @@ class Grape extends Events {
     } catch (ex) {
       return Buffer.from(val, enc || '')
     }
+  }
+
+  str2hashbuf (val) {
+    return createHash('sha256')
+      .update(val)
+      .digest()
   }
 
   onRequest (type, data, cb) {
@@ -174,40 +166,53 @@ class Grape extends Events {
     this.get(hash, cb)
   }
 
-  announce (val, port, cb) {
+  announce (val, port = this.conf.dht_port, cb) {
     if (!_.isInteger(port)) {
       return cb(new Error('ERR_GRAPE_SERVICE_PORT'))
     }
 
     cb = cb || noop
     this.node.announce(
-      this.str2hex(val),
-      port || this.conf.dht_port,
+      this.str2hashbuf(val),
+      { port },
       cb
     )
   }
 
   lookup (val, cb) {
-    const ih = this.str2hex(val)
+    const ih = this.str2hashbuf(val)
 
-    this.cbq0.push(ih, (err, data) => {
-      cb(err, data)
-    })
-
-    const kcnt = this.cbq0.cnt(ih)
-    if (kcnt > 1) return
-
-    this.node.lookup(ih, (err, cnt) => {
-      debug(`lookup ${val} found ${cnt} nodes`)
-
+    this.node.lookup(ih, (err, result) => {
       if (err) {
-        return this.cbq0.trigger(ih, err, null)
+        cb(err)
+        return
+      }
+      for (const { node, peers, localPeers } of result) {
+        if (localPeers) {
+          for (const peer of localPeers) {
+            const { port, host } = peer
+            const local = true
+            const referrer = null
+            const id = `${host}:${port}`
+            this._mem.add(ih, id)
+            this.emit('peer', id, { ih, port, host, local, referrer })
+          }
+        }
+
+        if (peers) {
+          for (const peer of peers) {
+            const { port, host } = peer
+            const local = false
+            const referrer = node
+            const id = `${host}:${port}`
+            this._mem.add(ih, id)
+            this.emit('peer', id, { ih, port, host, local, referrer })
+          }
+        }
       }
 
-      setImmediate(() => {
-        const peers = this._mem.get(ih, 100)
-        this.cbq0.trigger(ih, null, peers)
-      })
+      const peers = this._mem.get(ih, 100)
+      cb(null, peers)
     })
   }
 
@@ -322,6 +327,11 @@ class Grape extends Events {
     this._interface.http = server
   }
 
+  address () {
+    if (!this.dht) throw (Error('ERR_NOT_BOUND'))
+    return this.dht.address()
+  }
+
   start (cb) {
     cb = cb || noop
 
@@ -329,13 +339,10 @@ class Grape extends Events {
       debug('skipping start, since Grape is already active')
       return cb()
     }
-
     debug('starting')
-
     this.createNode(
       (err, node) => {
         if (err) return cb(err)
-
         this.node = node
 
         this.transportHttp(err => {
@@ -350,7 +357,11 @@ class Grape extends Events {
   stop (cb) {
     cb = cb || noop
     async.series([
-      (cb) => this.node ? this.node.destroy(cb) : cb(),
+      (cb) => {
+        if (!this.node) return cb()
+        this.node.once('close', cb)
+        this.node.destroy()
+      },
       (cb) => {
         let httpsSrv = this._interface.http
         if (!httpsSrv) return cb()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "micro-services"
   ],
   "dependencies": {
-    "@hyperswarm/dht": "0.0.1",
+    "@hyperswarm/dht": "0.1.0",
     "async": "^2.6.1",
     "cbq": "0.0.1",
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "micro-services"
   ],
   "dependencies": {
+    "@hyperswarm/dht": "0.0.1",
     "async": "^2.6.1",
-    "bittorrent-dht": "^9.0.0",
     "cbq": "0.0.1",
     "debug": "^4.0.1",
     "ed25519-supercop": "^1.2.0",
@@ -21,7 +21,7 @@
     "yargs": "^12.0.2"
   },
   "engine": {
-    "node": ">=6.0"
+    "node": ">=8.0"
   },
   "bin": {
     "grape": "bin/grape.js"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "dependencies": {
     "@hyperswarm/dht": "0.1.0",
     "async": "^2.6.1",
-    "cbq": "0.0.1",
     "debug": "^4.0.1",
-    "ed25519-supercop": "^1.2.0",
     "lodash": "^4.17.11",
     "raw-body": "^2.3.2",
     "record-cache": "^1.1.0",

--- a/test/announce.js
+++ b/test/announce.js
@@ -11,7 +11,6 @@ const {
 describe('service announce', () => {
   it('should find services', (done) => {
     const { grape1, grape2, stop } = createTwoGrapes()
-
     grape1.on('ready', () => {
       grape1.announce('rest:util:net', 1337, () => {})
     })
@@ -36,7 +35,7 @@ describe('service announce', () => {
       grape2.lookup('rest:util:net', (err, res) => {
         assert.strictEqual(err, null)
         assert.deepStrictEqual(res, [ '127.0.0.1:1337' ])
-        setTimeout(lookup, 300)
+        setTimeout(lookup, 300) // 300 because maxAge is at 200 in helper
       })
     })
 
@@ -60,7 +59,7 @@ describe('service announce', () => {
         function loop () {
           lookup((a, b) => {
             if (!a && !b) {
-              assert(lookups > 10)
+              assert(lookups > 10, 'lookups greater than 10')
               stop(done)
               return
             }


### PR DESCRIPTION
Just poking a hole through the canvas - many tests are still failing because of the transitional status. The main point of this first commit is to ensure that the first "service announce" announce tests passes (should find services). 

There's some work to do around exposing behaviour from hyperswarm dht around and then integrating it here. Some config options like maxTables, and some behaviours like dead peer management. but the biggest gap right now is the need for hyperswarm-dht to provide get/put (both immutable and mutable) functionality. See https://github.com/hyperswarm/dht/issues/7 

maxAge will also work as expected ('should remove outdated services') when https://github.com/hyperswarm/dht/commit/71d011728890c2dee0b8b9c2d6f2de4090c6a7bd is published (todo)



