### PR TITLE
Adaptive ephemerality [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ bind-to-address]
 Options:
   -b, --bind                 Listening host                             [string]
   --dp, --dht_port           DHT listening port              [number] [required]
-  --de, --dht_ephemeral      DHT node epemerality                       [number]
+  --de, --dht_ephemeral      DHT node epemerality                       [boolean]
+  --da, --dht_adaptive       DHT node adaptive ephemerality             [boolean]
   --dht_maxValues            DHT max values                             [number]
   --bn, --bootstrap          Bootstrap nodes                 [string] [required]
   --aph, --api_port          HTTP api port                   [number] [required]
@@ -74,6 +75,7 @@ g.start()
  - `options` &lt;Object&gt; Options for the link
     - `host` &lt;String&gt; IP to bind to. If null, Grape binds to all interfaces
     - `dht_ephemeral` &lt;Boolean&gt; Whether to join the DHT (false) or just query it (true). Default is false
+    - `dht_adaptive` &lt;Boolean&gt; Upgrade ephemeral node to persistent (join DHT) after 20-30 minutes uptime. Default is false
     - `dht_maxValues` &lt;Number&gt; Maximum number of DHT values
     - `dht_port` &lt;Number&gt; Port for DHT
     - `dht_bootstrap`: &lt;Array&gt; Bootstrap servers
@@ -96,11 +98,9 @@ Emitted when a potential peer is found.
 
 Emitted when the DHT finds a new node.
 
-
 #### Event: 'warning'
 
 Emitted when a warning occurs in the DHT.
-
 
 #### Event: 'announce'
 
@@ -109,6 +109,10 @@ Emitted when a peer announces itself in order to be stored in the DHT.
 #### Event: 'unannounce'
 
 Emitted when a peer unannounces itself in order to be removed from the DHT.
+
+#### Event: 'persistent'
+
+Emitted when a peer turns from ephemeral to persistent. Only applies when `dht_ephemeral` and `dht_adaptive` are both `true` at initialization.
 
 ## RPC API
 

--- a/bin/grape.js
+++ b/bin/grape.js
@@ -19,7 +19,12 @@ const program = require('yargs')
   .option('de', {
     describe: 'DHT node epemerality',
     alias: 'dht_ephemeral',
-    type: 'number'
+    type: 'boolean'
+  })
+  .option('de', {
+    describe: 'DHT node adaptive ephemerality',
+    alias: 'dht_adaptive',
+    type: 'boolean'
   })
   .option('dht_maxValues', {
     describe: 'DHT max values',

--- a/lib/Grape.js
+++ b/lib/Grape.js
@@ -43,6 +43,7 @@ class Grape extends Events {
     this.conf = _.defaults({}, conf, {
       host: null,
       dht_ephemeral: false,
+      dht_adaptive: false,
       dht_maxValues: 5000,
       dht_port: 20001,
       dht_bootstrap: [],
@@ -50,6 +51,10 @@ class Grape extends Events {
       dht_peer_maxAge: 120000,
       check_maxPayloadSize: 8192
     })
+
+    if (this.conf.dht_adaptive && this.conf.dht_ephemeral !== true) {
+      throw Error('dht_adaptive can only applied when dht_ephemeral: true')
+    }
 
     this._mem = records({
       maxSize: 5000,
@@ -67,6 +72,8 @@ class Grape extends Events {
 
   createNode (cb) {
     const dht = this.dht = DHT({
+      ephemeral: this.conf.dht_ephemeral,
+      adaptive: this.conf.dht_adaptive,
       maxValues: this.conf.dht_maxValues,
       bootstrap: this.conf.dht_bootstrap,
       maxAge: this.conf.dht_peer_maxAge
@@ -106,6 +113,11 @@ class Grape extends Events {
       debug(this.conf.dht_port, 'error', err)
     })
 
+    dht.on('persistent', () => {
+      debug(this.conf.dht_port, 'this peer has become non-ephemeral')
+      this.emit('persistent')
+    })
+
     const handleInitError = (err) => {
       this._initError = new GrapeError('ERR_GRAPE_INIT: ' + err.message)
       cb(err, dht)
@@ -118,6 +130,10 @@ class Grape extends Events {
         cb(null, dht)
       }
     })
+  }
+
+  get ephemeral () {
+    return this.dht.ephemeral
   }
 
   hex2str (val) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "micro-services"
   ],
   "dependencies": {
-    "@hyperswarm/dht": "^3.1.0",
+    "@hyperswarm/dht": "git+https://github.com/hyperswarm/dht.git#adaptive-ephemerality",
     "@hyperswarm/hypersign": "^2.1.0",
     "debug": "^4.0.1",
     "lodash": "^4.17.11",
@@ -19,7 +19,7 @@
     "yargs": "^12.0.2"
   },
   "engine": {
-    "node": ">=8.0"
+    "node": ">=10.0"
   },
   "bin": {
     "grape": "bin/grape.js"

--- a/test/Grape.js
+++ b/test/Grape.js
@@ -1,12 +1,12 @@
 'use strict'
 const Events = require('events')
-const { promisifyOf, when, once } = require('nonsynchronous')
+const { promisifyOf, when, timeout, once } = require('nonsynchronous')
 const { test, teardown } = require('tap')
 const getPort = require('get-port')
 const { Grape } = require('..')
 const stop = promisifyOf('stop')
 const start = promisifyOf('start')
-
+const { createBootstrap } = require('./helper.js')
 const guard = (grape) => teardown(() => grape.stop())
 
 test('Grape', async () => {
@@ -90,6 +90,26 @@ test('Grape', async () => {
       grape.stop(until)
     })
     await until.done()
+  })
+
+  test('dht_adaptive true when dht_ephemeral false', async ({ rejects, resolves }) => {
+    rejects(async () => {
+      new Grape({ // eslint-disable-line no-new
+        dht_port: await getPort(),
+        dht_ephemeral: false,
+        dht_adaptive: true
+      })
+    }, Error('dht_adaptive can only applied when dht_ephemeral: true'))
+    rejects(async () => {
+      new Grape({ // eslint-disable-line no-new
+        dht_port: await getPort(),
+        dht_adaptive: true
+      })
+    }, Error('dht_adaptive can only applied when dht_ephemeral: true'))
+    resolves(async () => {
+      const grape = new Grape({ dht_port: await getPort(), dht_adaptive: true, dht_ephemeral: true })
+      grape.stop()
+    })
   })
 
   test('dht port collision', async ({ ok, is }) => {
@@ -230,4 +250,67 @@ test('Grape', async () => {
     is(warning, 'test')
     await stop(grape)()
   })
+})
+
+test('adaptive ephemerality', async ({ is, pass, resolves, rejects, tearDown }) => {
+  const { setTimeout } = global
+  const { random } = Math
+  const divideTimeBy = 10000
+  const wait = (1000 * 60 * 25) / divideTimeBy
+  global.setTimeout = (fn, t, ...args) => {
+    return setTimeout(fn, t / divideTimeBy, ...args)
+  }
+  Math.random = () => 0.5
+  tearDown(() => {
+    global.setTimeout = setTimeout
+    Math.random = random
+    peer.stop()
+    adapt.stop()
+    bs.stop()
+  })
+
+  const bs = await createBootstrap(true)
+
+  const adapt = new Grape({
+    api_port: await getPort(),
+    dht_port: await getPort(),
+    dht_ephemeral: true,
+    dht_adaptive: true,
+    dht_bootstrap: bs.dht_bootstrap
+  })
+  adapt.start()
+  await once(adapt, 'ready')
+  const peer = new Grape({
+    api_port: await getPort(),
+    dht_port: await getPort(),
+    dht_ephemeral: true,
+    dht_bootstrap: bs.dht_bootstrap
+  })
+  peer.start()
+  const announce = promisifyOf('announce')
+  const lookup = promisifyOf('lookup')
+  await once(peer, 'ready')
+  const topic = 'rest:util:net'
+  await rejects(announce(peer)(topic, 1234), Error('No close nodes responded'), 'expected no nodes found')
+
+  const { setEphemeral } = adapt.dht
+  let setEphemeralCalled = false
+  adapt.dht.setEphemeral = (bool, cb) => {
+    setEphemeralCalled = true
+    is(bool, false)
+    return setEphemeral.call(adapt.dht, bool, cb)
+  }
+  is(adapt.ephemeral, true)
+  const dhtJoined = once(adapt, 'persistent')
+  resolves(dhtJoined, 'dht joined event fired')
+  is(setEphemeralCalled, false)
+  await timeout(wait)
+  is(setEphemeralCalled, true)
+  await dhtJoined
+  is(adapt.ephemeral, false)
+  await announce(peer)(topic, 1234)
+
+  lookup(peer)(topic)
+  const [, { referrer }] = await once(peer, 'peer')
+  is(Buffer.compare(referrer.id, adapt.dht.id), 0)
 })


### PR DESCRIPTION
Start a grape with `dht_ephemeral: true` and `dht_adaptive: true` and if the grape is long running - between 20-30mins (randomized range) uptime - the grape will become persistent (e.g. join the DHT). 

This can be a useful mode for reducing network noise and guarding against triggering cascading failure scenarios - if a peer keeps crashing, but it's in adaptive mode, then it will never join the DHT. Whereas if the peer is persistent (`dht_ephemeral: false`) on init, it will be exiting and rejoining the DHT. 

Default is still `dht_ephemeral: false` but it might be worth considering `dht_ephemeral: true`, `adaptive: true` as default in a future iteration