### PR TITLE
Release 0.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash": "^4.17.11",
     "raw-body": "^2.3.2",
     "record-cache": "^1.1.0",
-    "yargs": "^17.0.1"
+    "yargs": "^13.3.2"
   },
   "engine": {
     "node": ">=6.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash": "^4.17.11",
     "raw-body": "^2.3.2",
     "record-cache": "^1.1.0",
-    "yargs": "^12.0.2"
+    "yargs": "^17.0.1"
   },
   "engine": {
     "node": ">=6.0"
@@ -29,7 +29,7 @@
   "main": "index.js",
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^5.2.0",
+    "mocha": "^9.0.1",
     "request": "^2.88.0",
     "standard": "^12.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grenache-grape",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Granache Grape - DHT for micro-services",
   "author": "prdn <paolo@bitfinex.com> (https://bitfinex.com/)",
   "keywords": [


### PR DESCRIPTION
This PR bumps version to 0.9.11 as version 0.9.10 published in npm does not include the last two changes. 
It also fixes some low security vulnerabilities. 